### PR TITLE
Fix blog links in articles

### DIFF
--- a/blog/2017-08-12-understanding-the-nodejs-cluster-module.md
+++ b/blog/2017-08-12-understanding-the-nodejs-cluster-module.md
@@ -21,9 +21,9 @@ Hopefully for us NodeJS offers the [cluster](https://nodejs.org/api/cluster.html
 More on this series:
 
 1. **Understanding the NodeJS cluster module**
-2. [Using cluster module with HTTP servers](/2017/08/18/using-cluster-module-with-http-servers)
-3. [Using PM2 to manage a NodeJS cluster](/2017/08/20/using-pm2-to-manage-cluster)
-4. [Graceful shutdown NodeJS HTTP server when using PM2](/2017/08/27/graceful-shutdown-node-processes)
+2. [Using cluster module with HTTP servers](/blog/20170818/using-cluster-module-with-http-servers)
+3. [Using PM2 to manage a NodeJS cluster](/blog/20170820/using-pm2-to-manage-cluster)
+4. [Graceful shutdown NodeJS HTTP server when using PM2](/blog/20170827/graceful-shutdown-node-processes)
 
 ## Introducing the cluster module
 

--- a/blog/2017-08-18-using-cluster-module-with-http-servers.md
+++ b/blog/2017-08-18-using-cluster-module-with-http-servers.md
@@ -22,10 +22,10 @@ In the previous post [Understanding the NodeJS cluster module]({{ site.baseurl }
 ---
 More on this series:
 
-1. [Understanding the NodeJS cluster module](/2017/08/12/understanding-the-nodejs-cluster-module)
+1. [Understanding the NodeJS cluster module](/blog/20170812/understanding-the-nodejs-cluster-module)
 2. **Using cluster module with HTTP servers**
-3. [Using PM2 to manage a NodeJS cluster](/2017/08/20/using-pm2-to-manage-cluster)
-4. [Graceful shutdown NodeJS HTTP server when using PM2](/2017/08/27/graceful-shutdown-node-processes)
+3. [Using PM2 to manage a NodeJS cluster](/blog/20170820/using-pm2-to-manage-cluster)
+4. [Graceful shutdown NodeJS HTTP server when using PM2](/blog/20170827/graceful-shutdown-node-processes)
 
 ## Using cluster module with HTTP servers
 

--- a/blog/2017-08-20-using-pm2-to-manage-cluster.md
+++ b/blog/2017-08-20-using-pm2-to-manage-cluster.md
@@ -23,10 +23,10 @@ In this post we present [PM2](http://pm2.keymetrics.io) tool. although it is a g
 ---
 More on this series:
 
-1. [Understanding the NodeJS cluster module](/2017/08/12/understanding-the-nodejs-cluster-module)
-2. [Using cluster module with HTTP servers](/2017/08/18/using-cluster-module-with-http-servers)
+1. [Understanding the NodeJS cluster module](/blog/20170812/understanding-the-nodejs-cluster-module)
+2. [Using cluster module with HTTP servers](/blog/20170818/using-cluster-module-with-http-servers)
 3. **Using PM2 to manage a NodeJS cluster**
-4. [Graceful shutdown NodeJS HTTP server when using PM2](/2017/08/27/graceful-shutdown-node-processes)
+4. [Graceful shutdown NodeJS HTTP server when using PM2](/blog/20170827/graceful-shutdown-node-processes)
 
 ## Introducing PM2
 

--- a/blog/2017-08-27-graceful-shutdown-node-processes.md
+++ b/blog/2017-08-27-graceful-shutdown-node-processes.md
@@ -19,9 +19,9 @@ So you have created a NodeJS server that receives tons of requests and you are r
 ---
 More on this series:
 
-1. [Understanding the NodeJS cluster module](/2017/08/12/understanding-the-nodejs-cluster-module)
-2. [Using cluster module with HTTP servers](/2017/08/18/using-cluster-module-with-http-servers)
-3. [Using PM2 to manage a NodeJS cluster](/2017/08/20/using-pm2-to-manage-cluster)
+1. [Understanding the NodeJS cluster module](/blog/20170812/understanding-the-nodejs-cluster-module)
+2. [Using cluster module with HTTP servers](/blog/20170818/using-cluster-module-with-http-servers)
+3. [Using PM2 to manage a NodeJS cluster](/blog/20170820/using-pm2-to-manage-cluster)
 4. **Graceful shutdown NodeJS HTTP server when using PM2**
 
 ## Starting a HTTP server


### PR DESCRIPTION
- Links are redirecting to the 404 page. 
- Maybe due to a site upgrade?
- Fix the links (They were easy to guess correctly)